### PR TITLE
Trusty Vagrantfile actually used vivid64

### DIFF
--- a/ubuntu-trusty-64/Vagrantfile
+++ b/ubuntu-trusty-64/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "ubuntu/vivid64"
+  config.vm.box = "ubuntu/trusty64"
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs


### PR DESCRIPTION
When trying to _vagrant up_ an ubuntu-trusty64 box, vivid64 was actually used.
Fixed the box name in the Vagrantfile.
